### PR TITLE
Add activerecord to gem dependencies

### DIFF
--- a/activeantipattern.gemspec
+++ b/activeantipattern.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activerecord"
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
This PR adds activerecord as a dependency to this gem.

It's one of the most successful patterns I'm aware of. It's a pleasure to use but sometimes it bites you. And when it does the pain is comparable to all the suffering made by the Lich King in the Warcraft lore.